### PR TITLE
fix: ignore EADDRNOTAVAIL error when listen localhost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - 4
-  - 6
-  - 7
-  - 8
+  - '4'
+  - '6'
+  - '8'
+  - '10'
 install:
   - npm i npminstall && npminstall
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 environment:
   matrix:
-    - nodejs_version: 4
-    - nodejs_version: 6
-    - nodejs_version: 7
-    - nodejs_version: 8
+    - nodejs_version: '4'
+    - nodejs_version: '6'
+    - nodejs_version: '8'
+    - nodejs_version: '10'
 
 install:
   - ps: Install-Product node $env:nodejs_version
@@ -12,6 +12,6 @@ install:
 test_script:
   - node --version
   - npm --version
-  - npm run ci
+  - npm run test
 
 build: off

--- a/lib/detect-port.js
+++ b/lib/detect-port.js
@@ -56,7 +56,9 @@ function tryListen(port, maxPort, callback) {
 
       // 3. check localhost
       listen(port, 'localhost', err => {
-        if (err) {
+        // if localhost refer to the ip that is not unkonwn on the machine, you will see the error EADDRNOTAVAIL
+        // https://stackoverflow.com/questions/10809740/listen-eaddrnotavail-error-in-node-js
+        if (err && err.code !== 'EADDRNOTAVAIL') {
           return handleError(err);
         }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": ">= 4.2.1"
   },
   "ci": {
-    "version": "4, 6, 7, 8"
+    "version": "4, 6, 8, 10"
   },
   "homepage": "https://github.com/node-modules/detect-port",
   "license": "MIT"


### PR DESCRIPTION
if localhost refer to the ip that is not unkonwn on the machine, you will see the error EADDRNOTAVAIL

https://stackoverflow.com/questions/10809740/listen-eaddrnotavail-error-in-node-js